### PR TITLE
Standardize process timelines with card layout

### DIFF
--- a/src/app/commercial/page.tsx
+++ b/src/app/commercial/page.tsx
@@ -87,24 +87,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Review lease drawings, existing conditions, and
-                    business needs. Walk the space and confirm utilities, access, and staging.
-                  </li>
-                  <li>
-                    <strong>Design and permits.</strong> Coordinate drawings and ADA checks,
-                    track comments, and schedule inspections in the right order.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Sequence trades so work does not clash with
-                    daily operations. Keep dust, noise, and pathways managed in occupied buildings.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Finish punch items quickly, deliver O&amp;M docs
-                    and warranties, and confirm final sign-offs.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Review lease drawings, existing conditions, and business needs. Walk the space and confirm utilities, access, and staging.",
+                        },
+                        {
+                          step: "2",
+                          title: "Design & Permits",
+                          desc:
+                            "Coordinate drawings and ADA checks, track comments, and schedule inspections in the right order.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Sequence trades so work does not clash with daily operations. Keep dust, noise, and pathways managed in occupied buildings.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Finish punch items quickly, deliver O&M docs and warranties, and confirm final sign-offs.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines vary by jurisdiction, scope, and lead times. The schedule is confirmed
                   after design and permit milestones and is updated as work moves forward.

--- a/src/app/multi-family/page.tsx
+++ b/src/app/multi-family/page.tsx
@@ -84,28 +84,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Walk the property with management,
-                    confirm priorities, and map phasing by building or stack.
-                    Identify access, parking, and staging spots.
-                  </li>
-                  <li>
-                    <strong>Design and approvals.</strong> Prepare drawings and
-                    scopes, coordinate any engineering, confirm finishes, and set
-                    notice templates and posting schedule.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Work moves in clear phases with
-                    signage and protection. Dust, noise, and debris are controlled.
-                    Crews follow quiet hours and keep paths open where possible.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Punch items are closed quickly.
-                    Warranties and documentation are delivered to management or the
-                    board with photos as needed.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Walk the property with management, confirm priorities, and map phasing by building or stack. Identify access, parking, and staging spots.",
+                        },
+                        {
+                          step: "2",
+                          title: "Design & Approvals",
+                          desc:
+                            "Prepare drawings and scopes, coordinate any engineering, confirm finishes, and set notice templates and posting schedule.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Work moves in clear phases with signage and protection. Dust, noise, and debris are controlled. Crews follow quiet hours and keep paths open where possible.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Punch items are closed quickly. Warranties and documentation are delivered to management or the board with photos as needed.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines depend on scope, approvals, and lead times. A firm
                   schedule is shared after the walkthrough and planning steps, then

--- a/src/app/public-works/page.tsx
+++ b/src/app/public-works/page.tsx
@@ -86,28 +86,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Review bid documents, walk the
-                    site, confirm scope and phasing, and identify access and
-                    protection needs.
-                  </li>
-                  <li>
-                    <strong>Submittals and approvals.</strong> Prepare
-                    submittals, track comments, and move RFIs through the
-                    approval chain before work starts.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Follow the specs, hold
-                    pre-install meetings, schedule inspections in order, and
-                    keep daily reports current.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Deliver O&amp;M manuals,
-                    as-builts, warranties, and training as required by the
-                    contract.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Review bid documents, walk the site, confirm scope and phasing, and identify access and protection needs.",
+                        },
+                        {
+                          step: "2",
+                          title: "Submittals & Approvals",
+                          desc:
+                            "Prepare submittals, track comments, and move RFIs through the approval chain before work starts.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Follow the specs, hold pre-install meetings, schedule inspections in order, and keep daily reports current.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Deliver O&M manuals, as-builts, warranties, and training as required by the contract.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines depend on scope, approvals, and lead times. The
                   schedule is confirmed after the approval steps and is updated

--- a/src/app/residential/page.tsx
+++ b/src/app/residential/page.tsx
@@ -84,24 +84,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Walk the home, review goals and budget, and note utilities, access, and
-                    any safety or staging needs.
-                  </li>
-                  <li>
-                    <strong>Design and permits.</strong> Finalize drawings and selections. Handle permit submittals, plan
-                    reviews, and the inspection order.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Sequence trades in a logical path. Protect lived-in areas, manage dust
-                    and noise, and keep paths clear.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Complete punch items, share warranty and O&amp;M info, and confirm final
-                    sign-offs.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Walk the home, review goals and budget, and note utilities, access, and any safety or staging needs.",
+                        },
+                        {
+                          step: "2",
+                          title: "Design & Permits",
+                          desc:
+                            "Finalize drawings and selections. Handle permit submittals, plan reviews, and the inspection order.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Sequence trades in a logical path. Protect lived-in areas, manage dust and noise, and keep paths clear.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Complete punch items, share warranty and O&M info, and confirm final sign-offs.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines depend on jurisdiction, scope, and lead times. We confirm the schedule after design and permit
                   milestones and update you as work moves forward.

--- a/src/app/restaurants/page.tsx
+++ b/src/app/restaurants/page.tsx
@@ -85,28 +85,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Walk the site, confirm existing
-                    utilities, check for hood and grease interceptor needs, and
-                    review equipment lists with vendors.
-                  </li>
-                  <li>
-                    <strong>Design and permits.</strong> Submit hood and fire
-                    suppression plans, health department details, ADA items, and
-                    MEP drawings. Track comments and inspection order.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Rough-ins are placed to
-                    spec. Walls, tile, and washable surfaces go in. Equipment is
-                    set and connected after rough and finish inspections pass.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Final health, fire, and building
-                    inspections are scheduled. Punch items are closed and
-                    turnover documents are delivered.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Walk the site, confirm existing utilities, check for hood and grease interceptor needs, and review equipment lists with vendors.",
+                        },
+                        {
+                          step: "2",
+                          title: "Design & Permits",
+                          desc:
+                            "Submit hood and fire suppression plans, health department details, ADA items, and MEP drawings. Track comments and inspection order.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Rough-ins are placed to spec. Walls, tile, and washable surfaces go in. Equipment is set and connected after rough and finish inspections pass.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Final health, fire, and building inspections are scheduled. Punch items are closed and turnover documents are delivered.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines depend on scope, approvals, equipment lead times,
                   and finish selections. A working schedule is shared after

--- a/src/app/tenant-improvements/page.tsx
+++ b/src/app/tenant-improvements/page.tsx
@@ -85,27 +85,52 @@ export default function Page() {
 
               {/* Process & timeline */}
               <ContentSection id="process" title="Process and timeline">
-                <ol className="mt-3 list-decimal pl-5 space-y-2">
-                  <li>
-                    <strong>Assessment.</strong> Review lease and building rules,
-                    walk the space, confirm existing systems, access, and staging.
-                  </li>
-                  <li>
-                    <strong>Design and permits.</strong> Prepare drawings, ADA and
-                    fire/life safety items, coordinate MEP, and track comments and
-                    inspection order.
-                  </li>
-                  <li>
-                    <strong>Construction.</strong> Protect common areas, set
-                    barriers, and use negative air if needed. Trades are sequenced
-                    to reduce noise and downtime; off-hour work is scheduled when
-                    required.
-                  </li>
-                  <li>
-                    <strong>Closeout.</strong> Complete punch items quickly, deliver
-                    O&amp;M documents and warranties, and turn over a clean space.
-                  </li>
-                </ol>
+                <div className="bg-gray-100 rounded-xl p-6 sm:p-8">
+                  <div className="max-w-5xl mx-auto">
+                    <h3 className="text-xl font-semibold text-[#B21F24] text-center mb-8">
+                      Our Build Process
+                    </h3>
+                    <div className="grid md:grid-cols-4 gap-6 text-center">
+                      {[
+                        {
+                          step: "1",
+                          title: "Assessment",
+                          desc:
+                            "Review lease and building rules, walk the space, confirm existing systems, access, and staging.",
+                        },
+                        {
+                          step: "2",
+                          title: "Design & Permits",
+                          desc:
+                            "Prepare drawings, ADA and fire/life safety items, coordinate MEP, and track comments and inspection order.",
+                        },
+                        {
+                          step: "3",
+                          title: "Construction",
+                          desc:
+                            "Protect common areas, set barriers, and use negative air if needed. Trades are sequenced to reduce noise and downtime; off-hour work is scheduled when required.",
+                        },
+                        {
+                          step: "4",
+                          title: "Closeout",
+                          desc:
+                            "Complete punch items quickly, deliver O&M documents and warranties, and turn over a clean space.",
+                        },
+                      ].map(({ step, title, desc }) => (
+                        <div
+                          key={step}
+                          className="bg-white p-6 rounded-lg shadow-md shadow-gray-200/70"
+                        >
+                          <div className="h-12 w-12 mx-auto rounded-full bg-[#B21F24] text-white flex items-center justify-center text-xl font-bold mb-4">
+                            {step}
+                          </div>
+                          <h4 className="text-lg font-semibold mb-2">{title}</h4>
+                          <p className="text-sm leading-relaxed">{desc}</p>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
                 <p className="mt-3 text-gray-600">
                   Timelines depend on scope, approvals, building rules, and lead
                   times. A working schedule is shared after permit milestones and


### PR DESCRIPTION
## Summary
- refactor process/timeline sections on restaurant, public works, commercial, multi-family, tenant improvements, and residential pages to use the card-based grid format from disaster recovery

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a648ad4e1483308c2044656b111760